### PR TITLE
Configure git to fetch private go repositories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,3 +21,6 @@ ENV CGO_ENABLED=0
 ENV GO111MODULE=on
 
 USER ubuntu
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env sh
+
+set -e
+
+# For https://github.com
+if [ -n "$GITHUB_TOKEN" ]; then
+  git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+  cat ~/.gitconfig 1> /dev/null
+fi
+
+# For https://bitbucket.org
+# Ref: https://confluence.atlassian.com/bitbucket/oauth-on-bitbucket-cloud-238027431.html
+if [ -n "$BITBUCKET_TOKEN" ]; then
+  git config --global url."https://x-token-auth:${BITBUCKET_TOKEN}@bitbucket.org/".insteadOf "https://bitbucket.org/"
+  cat ~/.gitconfig 1> /dev/null
+fi
+
+# For https://gitlab.com
+# Ref: https://stackoverflow.com/questions/25409700/using-gitlab-token-to-clone-without-authentication
+if [ -n "$GITLAB_TOKEN" ]; then
+  git config --global url."https://oauth2:${GITLAB_TOKEN}@gitlab.com/".insteadOf "https://gitlab.com/"
+  cat ~/.gitconfig 1> /dev/null
+fi
+
+if [ "$1" = "go" ]; then
+  sh -c "$*"
+else
+  sh -c "go $*"
+fi


### PR DESCRIPTION
Related to https://github.com/renovatebot/renovate/issues/3202

This PR adds an `entrypoint` to Docker image for `go`. If a `GITHUB_TOKEN` environment variable is set/passed, this script will add a configuration to git client, so *private repositories* on GitHub can be fetched.

I see two concerns:

  - [x] Handle _GitHub_ 
  - [ ] Support _GitHub Enterprise_
  - [x] Make this change non-breaking (renovate passes `go` as docker command currently) 