### PR TITLE
Update Go version to 1.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ USER root
 
 RUN apt-get update && apt-get install -y wget git bzr && apt-get clean
 
-ENV GOLANG_VERSION 1.12.9
+ENV GOLANG_VERSION 1.13
 
 RUN wget -q -O go.tgz "https://golang.org/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz" && \
 	tar -C /usr/local -xzf go.tgz && \
@@ -18,6 +18,5 @@ RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 WORKDIR $GOPATH
 
 ENV CGO_ENABLED=0
-ENV GO111MODULE=on
 
 USER ubuntu


### PR DESCRIPTION
Updating Go version to the latest version `1.13`, so repos that using the latest version of Go can be updated by Renovatebot.

With Go `1.13` the `GO111MODULE` environment variable defaults to `auto`.