### PR TITLE
Disable Go module proxy and Go Checksum DB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,6 @@ RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 WORKDIR $GOPATH
 
 ENV CGO_ENABLED=0
+ENV GOPROXY=direct GOSUMDB=off
 
 USER ubuntu


### PR DESCRIPTION
With Go `1.13`, Go module proxy and Go Checksum DB are enabled by default.
You can read the release note for Go 1.13 at https://tip.golang.org/doc/go1.13

These two features are great feature that improves the speed and security.

The downside is with these features enabled by default, **private go modules** cannot be fetched. So, we either need to 

  - specify private modules by setting `GOPRIVATE` to `github.com/<org_name>` for each organization, or
  - disabling Go module proxy and checksum db

Since I don't how we can take the first approach for each organization, I proposed a change to implement the second approach.