### PR TITLE
feat: use official docker image for go files (WIP)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,26 @@
-FROM renovate/base@sha256:175e2d040a8dbd7900d815621e386efed1ca9c4f40e5aaf1902d4632f1bf645f
+FROM renovate/base@sha256:175e2d040a8dbd7900d815621e386efed1ca9c4f40e5aaf1902d4632f1bf645f as base
+
+FROM amd64/golang:1.14.0@sha256:fc7e7c9c4b0f6d2d5e8611ee73b9d1d3132750108878517bbf988aa772359ae4 as build
+
+
+FROM base as final
 
 USER root
 
 RUN apt-get update && apt-get install -y \
-	wget \
 	bzr \
 	mercurial \
 	&& rm -rf /var/lib/apt/lists/*
 
-ENV GOLANG_VERSION 1.14
-
-RUN wget -q -O go.tgz "https://golang.org/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz" && \
-	tar -C /usr/local -xzf go.tgz && \
-	rm go.tgz && \
-	export PATH="/usr/local/go/bin:$PATH"
+COPY --from=build /usr/local/go /usr/local/go
 
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
-RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chown -R ubuntu:0 && chmod -R 775 "$GOPATH"
 WORKDIR $GOPATH
 
 ENV CGO_ENABLED=0
 ENV GOPROXY=direct GOSUMDB=off
 
-USER ubuntu
+USER 1000

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,9 @@ RUN apt-get update && apt-get install -y \
 COPY --from=build /usr/local/go /usr/local/go
 
 ENV GOPATH /go
-ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+ENV PATH "$GOPATH/bin:/usr/local/go/bin:$PATH"
 
-RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chown -R ubuntu:0 && chmod -R 775 "$GOPATH"
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chown -R ubuntu:0 $GOPATH && chmod -R 775 $GOPATH
 WORKDIR $GOPATH
 
 ENV CGO_ENABLED=0


### PR DESCRIPTION
* refactor for base image updates
* use binaries from official go dockerimage
* `GOPATH` is owned by `ubuntu`

closes #18 